### PR TITLE
Add argument to account_pending

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -71,7 +71,13 @@ class RedmineOauthController < AccountController
       if user.active?
         successful_authentication(user)
       else
-        account_pending
+        # Redmine 2.4 adds an argument to account_pending
+        if Redmine::VERSION::MAJOR > 2 or
+          (Redmine::VERSION::MAJOR == 2 and Redmine::VERSION::MINOR >= 4)
+          account_pending(user)
+        else
+          account_pending
+        end
       end
     end
   end


### PR DESCRIPTION
Redmine 2.4 adds an argument to the account_pending function.  Check if
this installation is at least version 2.4, and if so, call account_pending
with the additional argument.

This is the same as #13, with the addition of version checking, to maintain support for Redmine < 2.4.
