### PR TITLE
Added missing oauth2 require

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -1,5 +1,6 @@
 require 'account_controller'
 require 'json'
+require 'oauth2'
 
 class RedmineOauthController < AccountController
   include Helpers::MailHelper


### PR DESCRIPTION
Fix for NameError (uninitialized constant RedmineOauthController::OAuth2):
  plugins/redmine_omniauth_google/app/controllers/redmine_oauth_controller.rb:86:in `oauth_client'
