### PR TITLE
Now new redmine usernames login is "user@domain.com" instead of "user"

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -47,7 +47,7 @@ class RedmineOauthController < AccountController
       user.firstname ||= info[:given_name]
       user.lastname ||= info[:family_name]
       user.mail = info["email"]
-      user.login = parse_email(info["email"])[:login]
+      user.login = info["email"]
       user.login ||= [user.firstname, user.lastname]*"."
       user.random_password
       user.register


### PR DESCRIPTION
I changed redmine login to a new look. It helps avoid duplicate users "root" and "admin" etc.
E.g. registering several sysadmins from several departments of University:
admin@physics.university.co.uk
admin@csd.university.co.uk
admin@biology.university.co.uk

Now it's possible. 
