### PR TITLE
Add backward compatibility code for :email_addresses

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -38,7 +38,11 @@ class RedmineOauthController < AccountController
   def try_to_login info
    params[:back_url] = session[:back_url]
    session.delete(:back_url)
-   user = User.joins(:email_addresses).where(:email_addresses => { :address => info["email"] }).first_or_create
+   if User.method_defined?(:email_addresses)
+     user = User.joins(:email_addresses).where(:email_addresses => { :address => info["email"] }).first_or_create
+   else
+     user = User.find_or_initialize_by(:mail => info["email"])
+   end
     if user.new_record?
       # Self-registration off
       redirect_to(home_url) && return unless Setting.self_registration?


### PR DESCRIPTION
Redmine in Debian stable does not support multiple email addresses yet. So, to support Debian stable's version of Redmine the plugin needs to check if the `:email_addresses` association is available for User.

The changes is made in the way, so the plugin will work on both versions of Redmine - on old Debian stable's one (2.5.2.devel, which is almost 3.0) and new 3.x ones. I.e. the style of the fix resembles https://github.com/twinslash/redmine_omniauth_google/pull/14.
