### PR TITLE
Don't break compatibility by supporting version 3

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -38,7 +38,12 @@ class RedmineOauthController < AccountController
   def try_to_login info
    params[:back_url] = session[:back_url]
    session.delete(:back_url)
-   user = User.joins(:email_addresses).where(:email_addresses => { :address => info["email"] }).first_or_create
+   
+    if Redmine::VERSION::MAJOR < 3
+      user = User.find_or_initialize_by_mail(info["email"])
+    else
+      user = User.joins(:email_addresses).where(:email_addresses => { :address => info["email"] }).first_or_create
+     
     if user.new_record?
       # Self-registration off
       redirect_to(home_url) && return unless Setting.self_registration?


### PR DESCRIPTION
Since version 3 multiple e-mails are allowed for a user. This requires a join which won't work with earlier versions.