### PR TITLE
Use https on Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'oauth2'
 gem 'json'


### PR DESCRIPTION
Kept like this, it yields an error on newer redmines:

```
Warning: the gem 'multipart-post' was found in multiple sources.
Installed from: https://rubygems.org/
Also found in:
  * http://rubygems.org/
You should add a source requirement to restrict this gem to your preferred source.
For example:
    gem 'multipart-post', :source => 'https://rubygems.org/'
```