### PR TITLE
Replace not working symbols to strings

### DIFF
--- a/app/controllers/redmine_oauth_controller.rb
+++ b/app/controllers/redmine_oauth_controller.rb
@@ -5,7 +5,7 @@ class RedmineOauthController < AccountController
   include Helpers::MailHelper
   include Helpers::Checker
   def oauth_google
-    if Setting.plugin_redmine_omniauth_google[:oauth_authentification]
+    if Setting.plugin_redmine_omniauth_google['oauth_authentification']
       session[:back_url] = params[:back_url]
       redirect_to oauth_client.auth_code.authorize_url(:redirect_uri => oauth_google_callback_url, :scope => scopes)
     else
@@ -83,7 +83,7 @@ class RedmineOauthController < AccountController
   end
 
   def oauth_client
-    @client ||= OAuth2::Client.new(settings[:client_id], settings[:client_secret],
+    @client ||= OAuth2::Client.new(settings['client_id'], settings['client_secret'],
       :site => 'https://accounts.google.com',
       :authorize_url => '/o/oauth2/auth',
       :token_url => '/o/oauth2/token')

--- a/app/views/hooks/_view_account_login_bottom.html.erb
+++ b/app/views/hooks/_view_account_login_bottom.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag 'buttons', :plugin => 'redmine_omniauth_google' %>
 
-<% if Setting.plugin_redmine_omniauth_google[:oauth_authentification] %>
+<% if Setting.plugin_redmine_omniauth_google['oauth_authentification'] %>
   <%= link_to oauth_google_path(:back_url => back_url) do %>
     <%= button_tag :class => 'button-login' do %>
       <%= image_tag('/plugin_assets/redmine_omniauth_google/images/google_login_icon.png', :class => 'button-login-icon', :alt => l(:login_via_google)) %>

--- a/app/views/settings/_google_settings.html.erb
+++ b/app/views/settings/_google_settings.html.erb
@@ -1,16 +1,16 @@
 <p>
   <label>Client ID:</label>
-  <%= text_field_tag 'settings[client_id]', @settings[:client_id] %>
+  <%= text_field_tag 'settings[client_id]', @settings['client_id'] %>
 </p>
 <p>
   <label>Client Secret:</label>
-  <%= text_field_tag 'settings[client_secret]', @settings[:client_secret] %>
+  <%= text_field_tag 'settings[client_secret]', @settings['client_secret'] %>
 </p>
 <p>
   <label>Available domains</label>
-  <%= text_area_tag "settings[allowed_domains]", @settings[:allowed_domains], :rows => 5 %>
+  <%= text_area_tag "settings[allowed_domains]", @settings['allowed_domains'], :rows => 5 %>
 </p>
 <p>
   <label>Oauth authentification:</label>
-  <%= check_box_tag "settings[oauth_authentification]", true, @settings[:oauth_authentification] %>
+  <%= check_box_tag "settings[oauth_authentification]", true, @settings['oauth_authentification'] %>
 </p>

--- a/lib/helpers/checker.rb
+++ b/lib/helpers/checker.rb
@@ -1,7 +1,7 @@
 module Helpers
   module Checker
     def allowed_domain_for? email
-      allowed_domains = Setting.plugin_redmine_omniauth_google[:allowed_domains]
+      allowed_domains = Setting.plugin_redmine_omniauth_google['allowed_domains']
       return unless allowed_domains
       allowed_domains = allowed_domains.split
       return true if allowed_domains.empty?

--- a/test/functional/redmine_oauth_controller_test.rb
+++ b/test/functional/redmine_oauth_controller_test.rb
@@ -31,7 +31,7 @@ class RedmineOauthControllerTest < ActionController::TestCase
   end
 
   def test_oauth_google_with_enabled_oauth_authentification
-    Setting.plugin_redmine_omniauth_google[:oauth_authentification] = nil
+    Setting.plugin_redmine_omniauth_google['oauth_authentification'] = nil
     get :oauth_google
     assert_response 404
   end
@@ -100,7 +100,7 @@ class RedmineOauthControllerTest < ActionController::TestCase
   end
 
   def test_oauth_google_callback_with_not_allowed_email_domain
-    Setting.plugin_redmine_omniauth_google[:allowed_domains] = "twinslash.com"
+    Setting.plugin_redmine_omniauth_google['allowed_domains'] = "twinslash.com"
     set_response_body_stub
     get :oauth_google_callback
     assert_redirected_to :signin
@@ -108,7 +108,7 @@ class RedmineOauthControllerTest < ActionController::TestCase
 
   def test_oauth_google_callback_with_allowed_email_domain
     Setting.self_registration = '3'
-    Setting.plugin_redmine_omniauth_google[:allowed_domains] = parse_email(@default_response_body[:email])[:domain]
+    Setting.plugin_redmine_omniauth_google['allowed_domains'] = parse_email(@default_response_body[:email])[:domain]
     set_response_body_stub
     get :oauth_google_callback
     assert_redirected_to :controller => 'my', :action => 'account'


### PR DESCRIPTION
In Redmine 3.4.x, we can't store and modify setting like https://github.com/twinslash/redmine_omniauth_google/issues/40.
it caused by doesn't work of the symbols of `@settings`.