### PR TITLE
login button display center

### DIFF
--- a/assets/stylesheets/buttons.css
+++ b/assets/stylesheets/buttons.css
@@ -1,10 +1,8 @@
 .button-login {
-  position: relative;
-  left: 45%;
-  display: inline-block;
+  display: block;
   border: 1px solid #999;
   border-radius: 2px;
-  margin-top: 10px;
+  margin: 10px auto 0 auto;
   width: 135px;
   height: 25px;
   padding: 0;


### PR DESCRIPTION
This plugin's google login button is slightly right of center.
So I want to display center.